### PR TITLE
Problem in sharing secret on social networking services

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,7 +1,11 @@
 class NotesController < ApplicationController
 
   def show
-    @note = Note.where({ uuid: params[:note_uuid] }).first
+    @note = Note.where({ uuid: params[:id] }).first
+  end
+
+  def reveal
+    @note = Note.where({ uuid: params[:note_id] }).first
     if @note
       @note.destroy!
     else

--- a/app/views/notes/reveal.html.erb
+++ b/app/views/notes/reveal.html.erb
@@ -1,0 +1,5 @@
+<h2>Your message is -</h2>
+<br>
+<h3><%= @note.message %></h3>
+
+<p class="footer">This message has now been deleted from the server permanently</p>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,5 +1,3 @@
-<h2>Your message is -</h2>
+<h2>kevlar.io will permanently destroy this message once it has been read</h2>
+<%= link_to "I understand, show me the message", "/#{@note.uuid}/reveal" %>
 <br>
-<h3><%= @note.message %></h3>
-
-<p class="footer">This message has now been deleted from the server permanently</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
 
-  resources :notes
 
-  get 'new' => 'notes#new'
-  get ':note_uuid' => 'notes#show'
   root 'notes#new'
+
+  resources :notes, path: "" do
+    get "reveal" => "notes#reveal"
+  end
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,3 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-Agent: *
+Disallow: /*
+Allow: /$


### PR DESCRIPTION
Hi @adambutler,

Actually this does not seems to be a bug or any wrong in core `kevlar` but just wanted to tell you about it.

When you create a `secret` and share it with someone via `facebook` messages, `facebook` attempt a `GET` request on it and it's gone :boom:. Your friend receiving that message will get a `404` on the `secret`.

I guess this will happen for many social networking sites, like `twitter` will try to shorten the link in a tweet and it will also attempt a `GET` request on the `secret` and so on for other services.
